### PR TITLE
#88 fix: add cart.guard.ts to force the ngOnDestroy on Deactivate

### DIFF
--- a/db.json
+++ b/db.json
@@ -136,7 +136,7 @@
       "id": 7
     },
     {
-      "availableQuantity": 50,
+      "availableQuantity": 49,
       "name": "Test Dog",
       "breed": "Affenpinscher",
       "genre": "Male",
@@ -155,13 +155,17 @@
     {
       "id": 1,
       "userId": 1,
-      "summary": 481.08,
+      "summary": 633.08,
       "discount": 0,
-      "total": 481.08,
+      "total": 633.08,
       "dogs": [
         {
           "dogId": 6,
           "quantity": 2
+        },
+        {
+          "dogId": 8,
+          "quantity": 1
         }
       ]
     },

--- a/src/app/checkout/checkout.module.ts
+++ b/src/app/checkout/checkout.module.ts
@@ -9,6 +9,7 @@ import { CheckoutRoutingModule } from './checkout.route';
 import { CheckoutComponent } from './checkout.component';
 import { CartComponent } from './cart/cart.component';
 import { NgxSpinnerModule } from 'ngx-spinner';
+import { CartGuard } from './services/cart.guard';
 
 @NgModule({
   declarations: [CheckoutComponent, CartComponent],
@@ -20,7 +21,7 @@ import { NgxSpinnerModule } from 'ngx-spinner';
     MaterialModule,
     NgxSpinnerModule.forRoot({ type: 'ball-clip-rotate' }),
   ],
-  providers: [],
+  providers: [CartGuard],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class CheckoutModule {}

--- a/src/app/checkout/checkout.route.ts
+++ b/src/app/checkout/checkout.route.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { CheckoutComponent } from './checkout.component';
 import { CartComponent } from './cart/cart.component';
+import { CartGuard } from './services/cart.guard';
 
 const checkoutRouterConfig: Routes = [
   {
@@ -13,6 +14,7 @@ const checkoutRouterConfig: Routes = [
       {
         path: 'cart',
         component: CartComponent,
+        canDeactivate: [CartGuard],
       },
     ],
   },

--- a/src/app/checkout/services/cart.guard.ts
+++ b/src/app/checkout/services/cart.guard.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { CanDeactivate } from '@angular/router';
+
+import { CartComponent } from '../cart/cart.component';
+
+@Injectable()
+export class CartGuard implements CanDeactivate<CartComponent> {
+  constructor() {}
+
+  canDeactivate(component: CartComponent): boolean {
+    component.ngOnDestroy();
+    return true;
+  }
+}


### PR DESCRIPTION
The ngOnDestroy was being called one time after the route change. To force the ngOnDestroy and stop the cart component making unnecessary requests, I had to put in on a guard and insert it into a Deactivate.